### PR TITLE
Make it deployable with now

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+# This is used to be able to write to the flat-file-db
+FROM node
+
+RUN mkdir -p /opt/micro-analytics
+WORKDIR /opt/micro-analytics
+COPY . /opt/micro-analytics
+
+RUN npm install
+RUN npm run build
+
+EXPOSE 3000
+
+CMD [ "npm", "start" ]

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 Public analytics as a Node.js microservice, no sysadmin experience required.
 
-[![Build Status](https://travis-ci.org/micro-analytics/micro-analytics.svg?branch=master)](https://travis-ci.org/micro-analytics/micro-analytics)
+[![Build Status](https://travis-ci.org/micro-analytics/micro-analytics.svg?branch=master)](https://travis-ci.org/micro-analytics/micro-analytics) [![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/micro-analytics/micro-analytics-cli)
+
 
 A tiny analytics server with ~100 lines of code, easy to run and hack around on. It does one thing, and it does it well: count the views of something and making the views publicly accessible via an API.
 

--- a/now.json
+++ b/now.json
@@ -1,0 +1,4 @@
+{
+  "name": "micro-analytics",
+  "type": "docker"
+}


### PR DESCRIPTION
Without the dockerfile it throws access denied on opening the flat-file-db.

[Rendered version of new readme](https://github.com/micro-analytics/micro-analytics-cli/blob/now/README.md)