### PR TITLE
/realtime -> /_realtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ The example below shows how you can listen for events in the browser, just swap
 `my-deploy.now.sh` with your own domain and give it a try:
 
 ```es6
-const sse = new EventSource('https://my-deploy.now.sh/realtime')
+const sse = new EventSource('https://my-deploy.now.sh/_realtime')
 sse.onopen = function () { console.log('[sse] open') }
 sse.onerror = function (error) { console.error('[sse error]', error) }
 sse.addEventListener('micro-analytics-ping', function (e) { console.log('[sse]', e) })

--- a/src/handler.js
+++ b/src/handler.js
@@ -16,7 +16,7 @@ if (db.hasFeature("subscribe")) {
 module.exports = async function (req, res) {
   const { pathname, query } = url.parse(req.url, /* parseQueryString */ true)
 
-  if (pathname === '/realtime') {
+  if (pathname === '/_realtime') {
     if (sse) {
       sse.addClient(req, res);
     } else {


### PR DESCRIPTION
To avoid clashes when automatically tracking pageviews let's prefix an underscore?