### PR TITLE
Refactor cli to not exec npm start

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -6,7 +6,8 @@ const pkg = require('./package.json');
 
 updateNotifier({ pkg }).notify();
 
-exec('npm start -- ' + process.argv.join(' '), {
-  async: true,
-  cwd: __dirname
-})
+const supportsAsyncAwait = parseInt(process.version.slice(1).split('.').join('')) > 760
+
+const microAnalytics = supportsAsyncAwait ? './src/index' : './dist/index'
+
+require(microAnalytics)

--- a/package.json
+++ b/package.json
@@ -15,11 +15,16 @@
     "node": ">=6.0.0"
   },
   "scripts": {
-    "start": "node dist/index.js",
+    "start": "./cli.js",
     "build": "./node_modules/.bin/async-to-gen src --out-dir dist",
     "prepublish": "npm run build",
     "dev": "NODE_ENV=development nodemon --config package.json --exec async-node src/index.js",
     "test": "jest"
+  },
+  "jest": {
+    "collectCoverageFrom": [
+      "src/**/*.js"
+    ]
   },
   "author": "Max Stoiber <contact@mxstbr.com> (http://mxstbr.com/)",
   "license": "MIT",
@@ -44,13 +49,5 @@
     "jest": "^19.0.2",
     "nodemon": "^1.11.0",
     "request-promise": "^4.1.1"
-  },
-  "execMap": {
-    "js": "micro"
-  },
-  "jest": {
-    "collectCoverageFrom": [
-      "src/**/*.js"
-    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,8 +7,9 @@
   },
   "files": [
     "dist",
+    "src",
     "cli.js",
-    "adapter-tests"
+    "adapter-tests/unit-tests.js"
   ],
   "engineStrict": true,
   "engines": {


### PR DESCRIPTION
This will make the output a bit nicer and after the reason refactoring
for realtime it is not necessary to call micro.

It will use uncompiled sources if there is async await support. 

Before
```
~/dev/ma/micro-analytics(master) » ./cli.js --help

> micro-analytics-cli@2.0.1 start /Users/rolf/dev/ma/micro-analytics
> node dist/index.js "/Users/rolf/.nvm/versions/node/v7.7.2/bin/node" "/Users/rolf/dev/ma/micro-analytics/cli.js" "--help"


  Usage: micro-analytics [options] [command]

  Commands:

    help  Display help

  Options:

    -a, --adapter [value]  Database adapter used (defaults to "flat-file-db")
    -h, --help             Output usage information
    -H, --host [value]     Host to listen on (defaults to "0.0.0.0")
    -p, --port <n>         Port to listen on (defaults to 3000)
    -v, --version          Output the version number
```

After:
```
~/dev/ma/micro-analytics(refactor-cli) » ./cli.js --help

  Usage: micro-analytics [options] [command]

  Commands:

    help  Display help

  Options:

    -a, --adapter [value]  Database adapter used (defaults to "flat-file-db")
    -h, --help             Output usage information
    -H, --host [value]     Host to listen on (defaults to "0.0.0.0")
    -p, --port <n>         Port to listen on (defaults to 3000)
    -v, --version          Output the version number
```

Also, but not visible here the help screen now has nice colors 🙃