### PR TITLE
Add more adapter tests

### DIFF
--- a/adapter-tests/unit-tests.js
+++ b/adapter-tests/unit-tests.js
@@ -51,6 +51,10 @@ module.exports = function testAdapter(options) {
       });
     });
 
+    it('should return empty list of views when key has no views', async () => {
+      expect(await adapter.get('/c-key')).toEqual({ views: [] });
+    });
+
     it('should return all saves on getAll', async () => {
       await adapter.put('/a-key', { views: [{ time: 1490623474639 }] });
       await adapter.put('/another-key', { views: [{ time: 1490623474639 }] });

--- a/adapter-tests/unit-tests.js
+++ b/adapter-tests/unit-tests.js
@@ -65,6 +65,17 @@ module.exports = function testAdapter(options) {
       });
     });
 
+    it('should return filtered saves on getAll', async () => {
+      await adapter.put('/a-key', { views: [{ time: 1490623474639 }] });
+      await adapter.put('/another-key', { views: [{ time: 1490623474639 }] });
+      await adapter.put('/b-key', { views: [{ time: 1490623474639 }] });
+
+      expect(await adapter.getAll({ pathname: '/a' })).toEqual({
+        '/a-key': { views: [{ time: 1490623474639 }] },
+        '/another-key': { views: [{ time: 1490623474639 }] },
+      });
+    });
+
     it('should have check whether a key is stored with has', async () => {
       await adapter.put('/a-key', { views: [{ time: 1490623474639 }] });
 
@@ -73,7 +84,6 @@ module.exports = function testAdapter(options) {
     });
 
     if (typeof adapter.subscribe === "function") {
-
       it('should allow subscription with observables', async () => {
         const listener = jest.fn();
         const unsubscribe = adapter.subscribe(listener);

--- a/adapter-tests/unit-tests.js
+++ b/adapter-tests/unit-tests.js
@@ -23,6 +23,26 @@ module.exports = function testAdapter(options) {
       });
     }
 
+    test('get() should return a promise', () => {
+      expect(adapter.get('/a-key').constructor.name).toEqual("Promise")
+    })
+
+    test('getAll() should return a promise', () => {
+      expect(adapter.getAll({ pathname: '/' }).constructor.name).toEqual("Promise")
+    })
+
+    test('has() should return a promise', () => {
+      expect(adapter.has('/a-key').constructor.name).toEqual("Promise")
+    })
+
+    test('keys() should return a promise', () => {
+      expect(adapter.keys().constructor.name).toEqual("Promise")
+    })
+
+    test('put() should return a promise', () => {
+      expect(adapter.put('/a-key', {}).constructor.name).toEqual("Promise")
+    })
+
     it('should save and read', async () => {
       await adapter.put('/a-key', { views: [{ time: 1490623474639 }] });
 

--- a/adapter-tests/unit-tests.js
+++ b/adapter-tests/unit-tests.js
@@ -100,6 +100,26 @@ module.exports = function testAdapter(options) {
       });
     });
 
+    it('should return filtered saves from get based on before', async () => {
+      await adapter.put('/a-key', {
+        views: [{ time: 1490623474639 }, { time: 1490623478639 }]
+      });
+
+      expect(await adapter.get('/a-key', { before: 1490623475640 })).toEqual({
+         views: [{ time: 1490623474639 }],
+      });
+    });
+
+    it('should return filtered saves from get based on after', async () => {
+      await adapter.put('/a-key', {
+        views: [{ time: 1490623474639 }, { time: 1490623478639 }]
+      });
+
+      expect(await adapter.get('/a-key', { after: 1490623475640 })).toEqual({
+         views: [{ time: 1490623478639 }],
+      });
+    });
+
     it('should have check whether a key is stored with has', async () => {
       await adapter.put('/a-key', { views: [{ time: 1490623474639 }] });
 

--- a/adapter-tests/unit-tests.js
+++ b/adapter-tests/unit-tests.js
@@ -65,7 +65,7 @@ module.exports = function testAdapter(options) {
       });
     });
 
-    it('should return filtered saves on getAll', async () => {
+    it('should return filtered saves from getAll based on pathname', async () => {
       await adapter.put('/a-key', { views: [{ time: 1490623474639 }] });
       await adapter.put('/another-key', { views: [{ time: 1490623474639 }] });
       await adapter.put('/b-key', { views: [{ time: 1490623474639 }] });
@@ -73,6 +73,30 @@ module.exports = function testAdapter(options) {
       expect(await adapter.getAll({ pathname: '/a' })).toEqual({
         '/a-key': { views: [{ time: 1490623474639 }] },
         '/another-key': { views: [{ time: 1490623474639 }] },
+      });
+    });
+
+    it('should return filtered saves from getAll based on before', async () => {
+      await adapter.put('/a-key', { views: [{ time: 1490623474639 }] });
+      await adapter.put('/another-key', { views: [{ time: 1490623478639 }] });
+      await adapter.put('/b-key', { views: [{ time: 1490623484639 }] });
+
+      expect(await adapter.getAll({ pathname: '/', before: 1490623478640 })).toEqual({
+        '/a-key': { views: [{ time: 1490623474639 }] },
+        '/another-key': { views: [{ time: 1490623478639 }] },
+        '/b-key': { views: [] },
+      });
+    });
+
+    it('should return filtered saves from getAll based on after', async () => {
+      await adapter.put('/a-key', { views: [{ time: 1490623474639 }] });
+      await adapter.put('/another-key', { views: [{ time: 1490623478639 }] });
+      await adapter.put('/b-key', { views: [{ time: 1490623484639 }] });
+
+      expect(await adapter.getAll({ pathname: '/', after: 1490623478638 })).toEqual({
+        '/a-key': { views: [] },
+        '/another-key': { views: [{ time: 1490623478639 }] },
+        '/b-key': { views: [{ time: 1490623484639 }] },
       });
     });
 

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -8,7 +8,12 @@ const DB = () => {
 
   return {
     sync: () => ({
-      get: (key) => data[key],
+      get: (key) => {
+        if (!{}.hasOwnProperty.call(data, key)) {
+          throw new Error('non-existing-key')
+        }
+        return data[key]
+      },
       put: (key, val, cb) => {
         setTimeout(() => {
           data[key] = val


### PR DESCRIPTION
- [x] Check return type of adapter functions
- [x] `get` of key that has no views
- [x] `getAll` filtering of pathnames
- [x] `get` filtering of time
- [x] `getAll` filtering of time