### PR TITLE
Add support for adapter cli config

### DIFF
--- a/adapter-tests/unit-tests.js
+++ b/adapter-tests/unit-tests.js
@@ -43,6 +43,43 @@ module.exports = function testAdapter(options) {
       expect(adapter.put('/a-key', {}).constructor.name).toEqual("Promise")
     })
 
+    if (typeof adapter.options !== "undefined") {
+      test('options should be an array of args options', () => {
+        expect(Array.isArray(adapter.options)).toBe(true)
+        if (adapter.options.length >= 0) {
+          let counter = 0
+          adapter.options.forEach(option => {
+            expect(option.name).toBeDefined()
+            expect(option.description).toBeDefined()
+            counter++
+          })
+
+          // if the forEach somehow breaks the test should break
+          expect(counter).toBe(adapter.options.length)
+        }
+      })
+
+      test('init should be a defined when options is defined', () => {
+        expect(typeof adapter.init).not.toBe("undefined");
+      })
+    } else {
+      test.skip('options should be an array of args options', () => {})
+      test.skip('init should be a defined when options is defined', () => {})
+    }
+
+    if (typeof adapter.init !== "undefined") {
+      test('init should be a function', () => {
+        expect(typeof adapter.init).toBe("function");
+      })
+
+      test('call init should not throw', () => {
+        adapter.init(options.initOptions || {})
+      })
+    } else {
+      test.skip('init should be a function', () => {})
+      test.skip('call init should not throw', () => {})
+    }
+
     it('should save and read', async () => {
       await adapter.put('/a-key', { views: [{ time: 1490623474639 }] });
 
@@ -167,6 +204,9 @@ module.exports = function testAdapter(options) {
           value: { views: [{ time: 1490623474639 }] },
         });
       });
+    } else {
+      it.skip('should allow subscription with observables', () => {})
+      it.skip('should allow multiple subscription with observables and handle unsubscribption', () => {})
     }
   });
 };

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "babel-polyfill": "^6.20.0",
     "babel-preset-node6": "^11.0.0",
     "jest": "^19.0.2",
+    "micro-analytics-adapter-memory": "^0.1.0",
     "nodemon": "^1.11.0",
     "request-promise": "^4.1.1"
   }

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "args": "^2.3.0",
     "flat-file-db": "^1.0.0",
     "micro": "6.1.0",
-    "micro-analytics-adapter-flat-file-db": "^1.2.1",
+    "micro-analytics-adapter-flat-file-db": "^1.3.0",
     "promise": "^7.1.1",
     "shelljs": "^0.7.6",
     "sse-channel": "^2.0.6",

--- a/src/db.js
+++ b/src/db.js
@@ -1,21 +1,8 @@
 const promise = require('promise')
 
 function initDbAdapter(options) {
-  let adapter
-  const repeatCharacter = (char, n) => `${Array(n + 1).join(char)}`
   const adapterName = options.adapter
-
-  try {
-    adapter = require(`micro-analytics-adapter-${adapterName}`)
-  } catch (err) {
-    if (err.code === 'MODULE_NOT_FOUND') {
-      // Console.error a warning message, but normally exit the process to avoid printing ugly npm ERR lines and stack trace.
-      console.error(`\n${repeatCharacter(' ', 22)}⚠️ ERROR ⚠️\n${repeatCharacter('-', 55)}\nYou specified "${adapterName}" as the DB_ADAPTER, but no package\ncalled "micro-analytics-adapter-${adapterName}" was found.\n\nPlease make sure you spelled the name correctly and\nhave "npm install"ed the necessary adapter package!\n${repeatCharacter('-', 55)}\n`)
-      process.exit(0)
-    } else {
-      throw err
-    }
-  }
+  const adapter = require(`micro-analytics-adapter-${adapterName}`)
 
 
   module.exports.get = adapter.get

--- a/src/db.js
+++ b/src/db.js
@@ -1,8 +1,9 @@
 const promise = require('promise')
 
-function initDbAdapter(adapterName) {
+function initDbAdapter(options) {
   let adapter
   const repeatCharacter = (char, n) => `${Array(n + 1).join(char)}`
+  const adapterName = options.adapter
 
   try {
     adapter = require(`micro-analytics-adapter-${adapterName}`)
@@ -17,14 +18,17 @@ function initDbAdapter(adapterName) {
   }
 
 
-  module.exports.get = adapter.get;
-  module.exports.getAll = adapter.getAll;
-  module.exports.put = adapter.put;
-  module.exports.has = adapter.has;
-  module.exports.keys = adapter.keys;
-  module.exports.subscribe = adapter.subscribe;
-  module.exports.hasFeature = (feature) => typeof adapter[feature] === "function";
+  module.exports.get = adapter.get
+  module.exports.getAll = adapter.getAll
+  module.exports.put = adapter.put
+  module.exports.has = adapter.has
+  module.exports.keys = adapter.keys
+  module.exports.subscribe = adapter.subscribe
+  module.exports.hasFeature = (feature) => typeof adapter[feature] === "function"
 
+  if (module.exports.hasFeature('init')) {
+    adapter.init(options)
+  }
 }
 
 module.exports = {

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,7 @@ const db = require('./db');
 
 const flags = parseArgs(process.argv)
 
-db.initDbAdapter(flags.adapter)
+db.initDbAdapter(flags)
 
 const handler = require('./handler')
 const server = micro(handler)

--- a/src/index.js
+++ b/src/index.js
@@ -3,22 +3,26 @@ const micro = require('micro')
 const parseArgs = require('./parseArgs')
 const db = require('./db');
 
-const flags = parseArgs(process.argv)
+try {
+  const flags = parseArgs(process.argv)
 
-db.initDbAdapter(flags)
+  db.initDbAdapter(flags)
 
-const handler = require('./handler')
-const server = micro(handler)
+  const handler = require('./handler')
+  const server = micro(handler)
 
-server.listen(flags.port, flags.host, (error) => {
-  if (error) {
-    console.error(error)
-    process.exit(1)
-  }
-
-  console.log(
-    'micro-analytics listening on ' + flags.host + ':' + flags.port + '\n' +
-    '  with adapter ' + flags.adapter +
-    (db.hasFeature("subscribe") ? '\n  with server side events' : '')
-  )
-})
+  server.listen(flags.port, flags.host, (error) => {
+    if (error) {
+      console.error(error)
+      process.exit(1)
+    }
+    console.log(
+      'micro-analytics listening on ' + flags.host + ':' + flags.port + '\n' +
+      '  with adapter ' + flags.adapter +
+      (db.hasFeature("subscribe") ? '\n  with server side events' : '')
+    )
+  })
+} catch (error) {
+  console.error(error.message)
+  process.exit(1)
+}

--- a/src/parseArgs.js
+++ b/src/parseArgs.js
@@ -1,5 +1,7 @@
 const args = require('args');
 
+const repeatCharacter = (char, n) => `${Array(n + 1).join(char)}`
+
 function adapterNameFromArgs(argv) {
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i]
@@ -23,9 +25,15 @@ module.exports = function parseArgs(argv) {
     if (adapter.options) {
       options = adapter.options
     }
-  } catch (error) {
-    if (error.code !== "MODULE_NOT_FOUND") {
-      throw error;
+  } catch (err) {
+    if (err.code === 'MODULE_NOT_FOUND') {
+      if (process.env.NODE_ENV !== 'test') {
+      // Console.error a warning message, but normally exit the process to avoid printing ugly npm ERR lines and stack trace.
+      console.error(`\n${repeatCharacter(' ', 22)}⚠️ ERROR ⚠️\n${repeatCharacter('-', 55)}\nYou specified "${adapterName}" as the DB_ADAPTER, but no package\ncalled "micro-analytics-adapter-${adapterName}" was found.\n\nPlease make sure you spelled the name correctly and\nhave "npm install"ed the necessary adapter package!\n${repeatCharacter('-', 55)}\n`)
+      process.exit(0)
+      }
+    } else {
+      throw err
     }
   }
 

--- a/src/parseArgs.js
+++ b/src/parseArgs.js
@@ -1,10 +1,38 @@
-
 const args = require('args');
 
+function adapterNameFromArgs(argv) {
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i]
+    if (arg === '-a' || arg === '--adapter') {
+      return argv[i + 1]
+    }
+    if (/--adapter=/.test(arg)) {
+      return arg.split('=')[1]
+    }
+  }
+
+  return process.env.DB_ADAPTER || 'flat-file-db'
+}
+
 module.exports = function parseArgs(argv) {
+  const adapterName = adapterNameFromArgs(argv);
+  let options = []
+
+  try {
+    const adapter =  require(`micro-analytics-adapter-${adapterName}`)
+    if (adapter.options) {
+      options = adapter.options
+    }
+  } catch (error) {
+    if (error.code !== "MODULE_NOT_FOUND") {
+      throw error;
+    }
+  }
+
   return args
     .option(['p', 'port'], 'Port to listen on', process.env.PORT || 3000, Number)
     .option(['H', 'host'], 'Host to listen on', process.env.HOST ||'0.0.0.0')
     .option(['a', 'adapter'], 'Database adapter used', process.env.DB_ADAPTER || 'flat-file-db')
+    .options(options)
     .parse(argv, { name: 'micro-analytics' })
 }

--- a/src/parseArgs.js
+++ b/src/parseArgs.js
@@ -27,11 +27,7 @@ module.exports = function parseArgs(argv) {
     }
   } catch (err) {
     if (err.code === 'MODULE_NOT_FOUND') {
-      if (process.env.NODE_ENV !== 'test') {
-      // Console.error a warning message, but normally exit the process to avoid printing ugly npm ERR lines and stack trace.
-      console.error(`\n${repeatCharacter(' ', 22)}⚠️ ERROR ⚠️\n${repeatCharacter('-', 55)}\nYou specified "${adapterName}" as the DB_ADAPTER, but no package\ncalled "micro-analytics-adapter-${adapterName}" was found.\n\nPlease make sure you spelled the name correctly and\nhave "npm install"ed the necessary adapter package!\n${repeatCharacter('-', 55)}\n`)
-      process.exit(0)
-      }
+      throw new Error(`\n${repeatCharacter(' ', 22)}⚠️ ERROR ⚠️\n${repeatCharacter('-', 55)}\nYou specified "${adapterName}" as the DB_ADAPTER, but no package\ncalled "micro-analytics-adapter-${adapterName}" was found.\n\nPlease make sure you spelled the name correctly and\nhave "npm install"ed the necessary adapter package!\n${repeatCharacter('-', 55)}\n`)
     } else {
       throw err
     }

--- a/tests/__snapshots__/parseArgs.test.js.snap
+++ b/tests/__snapshots__/parseArgs.test.js.snap
@@ -5,6 +5,8 @@ Object {
   "H": "0.0.0.0",
   "a": "flat-file-db",
   "adapter": "flat-file-db",
+  "d": "views.db",
+  "dbName": "views.db",
   "host": "0.0.0.0",
   "p": 3000,
   "port": 3000,

--- a/tests/__snapshots__/parseArgs.test.js.snap
+++ b/tests/__snapshots__/parseArgs.test.js.snap
@@ -12,3 +12,16 @@ Object {
   "port": 3000,
 }
 `;
+
+exports[`parseArgs should throw on non existing adapter 1`] = `
+"
+                      ⚠️ ERROR ⚠️
+-------------------------------------------------------
+You specified \\"not-a-real-adapter\\" as the DB_ADAPTER, but no package
+called \\"micro-analytics-adapter-not-a-real-adapter\\" was found.
+
+Please make sure you spelled the name correctly and
+have \\"npm install\\"ed the necessary adapter package!
+-------------------------------------------------------
+"
+`;

--- a/tests/atomicity.test.js
+++ b/tests/atomicity.test.js
@@ -6,7 +6,9 @@ const db = require('../src/db')
 const service = require('../src/handler')
 let url
 
-db.initDbAdapter('flat-file-db');
+beforeAll(() => {
+  db.initDbAdapter({ adapter: 'flat-file-db' });
+})
 
 beforeEach(async () => {
   url = await listen(service)

--- a/tests/errors.test.js
+++ b/tests/errors.test.js
@@ -5,7 +5,9 @@ const service = require('../src/handler')
 const db = require('../src/db')
 let url
 
-db.initDbAdapter('flat-file-db');
+beforeAll(() => {
+  db.initDbAdapter({ adapter: 'flat-file-db' });
+})
 
 beforeEach(async () => {
   url = await listen(service)

--- a/tests/items.test.js
+++ b/tests/items.test.js
@@ -6,7 +6,9 @@ const db = require('../src/db')
 const service = require('../src/handler')
 let url
 
-db.initDbAdapter('flat-file-db');
+beforeAll(() => {
+  db.initDbAdapter({ adapter: 'flat-file-db' });
+})
 
 beforeEach(async () => {
   mockDb._reset()

--- a/tests/parseArgs.test.js
+++ b/tests/parseArgs.test.js
@@ -1,7 +1,6 @@
 jest.mock('pkginfo', () => () => ({version: '1.0.0'}))
 const parseArgs = require('../src/parseArgs')
 
-
 describe('parseArgs', () => {
   it("should have correct defaults", () => {
     expect(parseArgs(['node', 'micro-analytics'])).toMatchSnapshot();
@@ -24,4 +23,25 @@ describe('parseArgs', () => {
     expect(parseArgs(['node', 'micro-analytics']).host).toEqual('localhost');
     delete process.env.HOST
   })
+
+  it('should use get adapter option when using -a', () => {
+    process.env.DB_ADAPTER = 'redis'
+    const args = ['node', 'micro-analytics', '-a', 'flat-file-db']
+    expect(Object.keys(parseArgs(args))).toContain('dbName');
+    delete process.env.DB_ADAPTER
+  });
+
+  it('should use get adapter option when using --adapter', () => {
+    process.env.DB_ADAPTER = 'redis'
+    const args = ['node', 'micro-analytics', '--adapter', 'flat-file-db']
+    expect(Object.keys(parseArgs(args))).toContain('dbName');
+    delete process.env.DB_ADAPTER
+  });
+
+  it('should use get adapter option when using --adapter=', () => {
+    process.env.DB_ADAPTER = 'redis'
+    const args = ['node', 'micro-analytics', '--adapter=flat-file-db']
+    expect(Object.keys(parseArgs(args))).toContain('dbName');
+    delete process.env.DB_ADAPTER
+  });
 })

--- a/tests/parseArgs.test.js
+++ b/tests/parseArgs.test.js
@@ -6,9 +6,15 @@ describe('parseArgs', () => {
     expect(parseArgs(['node', 'micro-analytics'])).toMatchSnapshot();
   })
 
+  it('should throw on non existing adapter', () => {
+    expect(() => {
+      parseArgs(['node', 'micro-analytics', '-a', 'not-a-real-adapter'])
+    }).toThrowErrorMatchingSnapshot()
+  });
+
   it("should use DB_ADAPTER environment variable as default if set", () => {
-    process.env.DB_ADAPTER = 'redis'
-    expect(parseArgs(['node', 'micro-analytics']).adapter).toEqual('redis');
+    process.env.DB_ADAPTER = 'memory'
+    expect(parseArgs(['node', 'micro-analytics']).adapter).toEqual('memory');
     delete process.env.DB_ADAPTER
   })
 

--- a/tests/sse.test.js
+++ b/tests/sse.test.js
@@ -4,7 +4,9 @@ const db = require('../src/db')
 const sseHandler = require('../src/sse')
 let url
 
-db.initDbAdapter('flat-file-db');
+beforeAll(() => {
+  db.initDbAdapter({ adapter: 'flat-file-db' });
+})
 
 beforeEach(() => {
   mockDb._reset()

--- a/writing-adapters.md
+++ b/writing-adapters.md
@@ -7,23 +7,30 @@ If you want to see an example adapter, check out the default [`flat-file-db` ada
 ## Overview
 
 The methods every adapter has to have are:
+- `get(key: string): Promise`: Get a value from the database
+- `put(key: string, value: object): Promise`: Put a value into the database
+- `has(key: string): Promise`: Check if the database has a value for a certain key
+- `getAll(options?): Promise`: Get all values from the database as JSON
 
-- `get(key: string)`: Get a value from the database
-- `put(key: string, value: object)`: Put a value into the database
-- `has(key: string)`: Check if the database has a value for a certain key
-- `getAll(options?)`: Get all values from the database as JSON
+All of these methods have to return Promises. On top of that there is some optional methods:
 
-All of these methods have to return Promises. On top of that there is one more method, which returns an Observer (based on the [proposed spec](https://github.com/tc39/proposal-observable))
+- `init(options: Object): void`: A method to setup the adapter based on
+- `subscribe(pathname?: string): Observer`: Subscribe to changes of all keys starting with a certain `pathname`. If no pathname is provided, subscribe to all changes. It returns an Observer (based on the [proposed spec](https://github.com/tc39/proposal-observable))
 
-- `subscribe(pathname?: string)`: Subscribe to changes of all keys starting with a certain `pathname`. If no pathname is provided, subscribe to all changes.
+Furthermore, there are some non callable fields:
+- `options: Array<ArgsOption>`: An array of cli options that is needed to configure the adapter. The elements in the list should be compatible with the options of the [args library][args-options]. It is important to read environment variables and put that in the `defaultValue` field to support configuration through environment variables. The parsed options will be passed to `init` described above, thus, `init` is required when options is defined.
+
+[args-options]: https://github.com/leo/args#optionslist
 
 This is what the export of an adapter should thusly look like:
 
 ```JS
 // index.js
-const { get, put, getAll, has, subscribe } = require('./adapter')
+const { init, options, get, put, getAll, has, subscribe } = require('./adapter')
 
 module.exports = {
+  init,
+  options,
   get,
   put,
   getAll,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1836,6 +1836,10 @@ micro-analytics-adapter-flat-file-db@^1.2.1:
     then-flat-file-db "^1.0.0"
     zen-observable "^0.4.0"
 
+micro-analytics-adapter-memory@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/micro-analytics-adapter-memory/-/micro-analytics-adapter-memory-0.1.0.tgz#c8bcdb5e4e46be156d610be73931ab9a7456f329"
+
 micro@6.1.0:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/micro/-/micro-6.1.0.tgz#c933e1dd90dea56b0517b62b2af00d3f5351d79d"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1827,9 +1827,9 @@ merge@^1.1.3:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/merge/-/merge-1.2.0.tgz#7531e39d4949c281a66b8c5a6e0265e8b05894da"
 
-micro-analytics-adapter-flat-file-db@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/micro-analytics-adapter-flat-file-db/-/micro-analytics-adapter-flat-file-db-1.2.1.tgz#df07df652ad4de129c1ab2def5fa73dd2d7e8763"
+micro-analytics-adapter-flat-file-db@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/micro-analytics-adapter-flat-file-db/-/micro-analytics-adapter-flat-file-db-1.3.0.tgz#ba96307cc148b77dfa6370cbca3d713da9309fcd"
   dependencies:
     escape-regex "^1.0.7"
     flat-file-db "^1.0.0"


### PR DESCRIPTION
This adds the possibility to configure adapters through the cli. It will also add the options to the help screen e.g. `--db-name` for flat-file-adapter 👇 

```
  Usage: micro-analytics [options] [command]

  Commands:

    help  Display help

  Options:

    -a, --adapter [value]  Database adapter used (defaults to "flat-file-db")
    -d, --db-name [value]  The name of the flat-file-db file. (defaults to "views.db")
    -h, --help             Output usage information
    -H, --host [value]     Host to listen on (defaults to "0.0.0.0")
    -p, --port <n>         Port to listen on (defaults to 3000)
    -v, --version          Output the version number
```

It adds to new parts to adapters:
* `init(options)` - a function used to setup up the adapter, will be passed all cli options.
* `options` - an array of options for leo/args
 
### Todo
- [ ] Wait for https://github.com/micro-analytics/adapter-flat-file-db/pull/7
- [x] Add tests to adapter-tests for options and init
- [x] Document in how to write adapter docs.