### PR TITLE
Add support for metadata with post requests

### DIFF
--- a/packages/adapter-utils/package-lock.json
+++ b/packages/adapter-utils/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "micro-analytics-adapter-utils",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "dependencies": {
     "ansi-regex": {

--- a/packages/micro-analytics-cli/package-lock.json
+++ b/packages/micro-analytics-cli/package-lock.json
@@ -75,11 +75,6 @@
       "integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0=",
       "dev": true
     },
-    "async-to-gen": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/async-to-gen/-/async-to-gen-1.1.4.tgz",
-      "integrity": "sha1-C6oqddWyK0EQVNXIXkoMBvz5do0="
-    },
     "babel-cli": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-cli/-/babel-cli-6.24.1.tgz",
@@ -225,8 +220,7 @@
     "bluebird": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
-      "integrity": "sha1-eRQg1/VR7qKJdFOop3ZT+WYG1nw=",
-      "dev": true
+      "integrity": "sha1-eRQg1/VR7qKJdFOop3ZT+WYG1nw="
     },
     "boxen": {
       "version": "0.6.0",
@@ -288,6 +282,28 @@
       "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
       "integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM="
     },
+    "clipboardy": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/clipboardy/-/clipboardy-1.1.1.tgz",
+      "integrity": "sha1-dbWnrFDYPJgCX7YwMpjGqQB8Fsc=",
+      "dependencies": {
+        "execa": {
+          "version": "0.6.3",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-0.6.3.tgz",
+          "integrity": "sha1-V7aaWU8IF1nGnlNw8NF7nLEWWP4="
+        },
+        "npm-run-path": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+          "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8="
+        },
+        "path-key": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+          "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
+        }
+      }
+    },
     "code-point-at": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
@@ -343,6 +359,21 @@
       "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
       "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y="
     },
+    "cross-spawn": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+      "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk="
+    },
+    "cross-spawn-async": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/cross-spawn-async/-/cross-spawn-async-2.2.5.tgz",
+      "integrity": "sha1-hF/wwINKPe2dFg2sptOQkGuyiMw="
+    },
+    "crypto-random-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
+      "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4="
+    },
     "debug": {
       "version": "0.7.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
@@ -374,6 +405,11 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
       "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME="
+    },
+    "duplexer3": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
+      "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
     },
     "duplexify": {
       "version": "3.5.0",
@@ -427,6 +463,11 @@
       "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
       "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
       "dev": true
+    },
+    "execa": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-0.4.0.tgz",
+      "integrity": "sha1-TrZGejaglfq7KXD/nV4/t7zm68M="
     },
     "expand-brackets": {
       "version": "0.1.5",
@@ -1160,6 +1201,16 @@
         }
       }
     },
+    "get-port": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/get-port/-/get-port-3.1.0.tgz",
+      "integrity": "sha1-7wGxioTKZIaXD/meVERhQac//T4="
+    },
+    "get-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+      "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
+    },
     "glob": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
@@ -1216,11 +1267,6 @@
       "integrity": "sha1-AHa59GonBQbduq6lZJaJdGBhKmc=",
       "dev": true
     },
-    "iconv-lite": {
-      "version": "0.4.13",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz",
-      "integrity": "sha1-H4irpKsLFQjoMSrMOTRfNumS4vI="
-    },
     "ignore-by-default": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
@@ -1268,6 +1314,11 @@
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
       "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
       "dev": true
+    },
+    "ip": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
+      "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
     },
     "is-arrayish": {
       "version": "0.2.1",
@@ -1390,6 +1441,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+    },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
     },
     "isobject": {
       "version": "2.1.0",
@@ -1548,10 +1604,15 @@
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
       "integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY="
     },
-    "magic-string": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.16.0.tgz",
-      "integrity": "sha1-lw67DacZMwEoX7GqZQ85vdgetFo="
+    "lru-cache": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
+      "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew=="
+    },
+    "make-dir": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.0.0.tgz",
+      "integrity": "sha1-l6ARdR6R3YfPre9Ygy67BJNt6Xg="
     },
     "map-stream": {
       "version": "0.1.0",
@@ -1565,9 +1626,116 @@
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
     },
     "micro": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/micro/-/micro-6.1.0.tgz",
-      "integrity": "sha1-yTPh3ZDepWsFF7YrKvANP1NR150="
+      "version": "7.3.3",
+      "resolved": "https://registry.npmjs.org/micro/-/micro-7.3.3.tgz",
+      "integrity": "sha1-gmHFbSoxp9+TmG7/hkQTlvK0sHA=",
+      "dependencies": {
+        "ansi-align": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz",
+          "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38="
+        },
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+        },
+        "async-to-gen": {
+          "version": "1.3.3",
+          "resolved": "https://registry.npmjs.org/async-to-gen/-/async-to-gen-1.3.3.tgz",
+          "integrity": "sha1-1SyftIAfDfRKvE0t4YcLSLYOILs="
+        },
+        "boxen": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/boxen/-/boxen-1.1.0.tgz",
+          "integrity": "sha1-sbad1SIwXoB6md7ud329blFnsQI="
+        },
+        "configstore": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.0.tgz",
+          "integrity": "sha1-Rd+QcHPibfoc9LLVL1tgVF6qEdE="
+        },
+        "dot-prop": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.1.1.tgz",
+          "integrity": "sha1-qEk/C3te7sglJbXHWH+n3nyoWcE="
+        },
+        "got": {
+          "version": "6.7.1",
+          "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
+          "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA="
+        },
+        "iconv-lite": {
+          "version": "0.4.15",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.15.tgz",
+          "integrity": "sha1-/iZaIYrGpXz+hUkn6dBMGYJe3es="
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+        },
+        "latest-version": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-3.1.0.tgz",
+          "integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU="
+        },
+        "lazy-req": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/lazy-req/-/lazy-req-2.0.0.tgz",
+          "integrity": "sha1-yUUKNj7N2i5vDHATKtTzf48G8rQ="
+        },
+        "magic-string": {
+          "version": "0.19.1",
+          "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.19.1.tgz",
+          "integrity": "sha1-FNdoATyvLsj96hakmvgvw3fnUgE="
+        },
+        "package-json": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/package-json/-/package-json-4.0.1.tgz",
+          "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0="
+        },
+        "raw-body": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.2.0.tgz",
+          "integrity": "sha1-mUl2z2pQlqQRYoQEkvC9xdbn+5Y="
+        },
+        "string-width": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.0.tgz",
+          "integrity": "sha1-AwZkVh/BRslCPsfZeP4kV0N/5tA="
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8="
+        },
+        "timed-out": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
+          "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
+        },
+        "unzip-response": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-2.0.1.tgz",
+          "integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c="
+        },
+        "update-notifier": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.1.0.tgz",
+          "integrity": "sha1-7AweU1NrdmR6JLd8uDlm2TFRI9k="
+        },
+        "write-file-atomic": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.1.0.tgz",
+          "integrity": "sha512-0TZ20a+xcIl4u0+Mj5xDH2yOWdmQiXlKf9Hm+TgDXjTMsEYb+gDrmb8e8UNAzMCitX8NBqG4Z/FUQIyzv/R1JQ=="
+        },
+        "xdg-basedir": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
+          "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ="
+        }
+      }
     },
     "micro-analytics-adapter-flat-file-db": {
       "version": "1.3.0",
@@ -1629,6 +1797,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/node-status-codes/-/node-status-codes-1.0.0.tgz",
       "integrity": "sha1-WuVUHQJGRdMqWPzdyc7s6nrjrC8="
+    },
+    "node-version": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-version/-/node-version-1.0.0.tgz",
+      "integrity": "sha1-G5uVhKmn96YSPyFc0UplK/IasZ4="
     },
     "nodemon": {
       "version": "1.11.0",
@@ -1724,6 +1897,11 @@
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
       "dev": true
     },
+    "npm-run-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-1.0.0.tgz",
+      "integrity": "sha1-9cMr9ZX+ga6Sfa7FLoL4sACsPI8="
+    },
     "number-is-nan": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
@@ -1780,6 +1958,11 @@
         }
       }
     },
+    "p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
+    },
     "p-limit": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.1.0.tgz",
@@ -1819,6 +2002,11 @@
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
+    "path-key": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-1.0.0.tgz",
+      "integrity": "sha1-XVPVeAGWRsDWiADbThRua9wqx68="
+    },
     "path-parse": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
@@ -1839,8 +2027,7 @@
     "pify": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-      "dev": true
+      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
     },
     "pinkie": {
       "version": "2.0.4",
@@ -1890,6 +2077,11 @@
       "integrity": "sha1-tCGyQUDWID8e08dplrRCewjowBQ=",
       "dev": true
     },
+    "pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
+    },
     "punycode": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
@@ -1923,11 +2115,6 @@
           "dev": true
         }
       }
-    },
-    "raw-body": {
-      "version": "2.1.7",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.1.7.tgz",
-      "integrity": "sha1-rf6s4uT7MJgFgBTQjActzFl1h3Q="
     },
     "rc": {
       "version": "1.2.1",
@@ -2075,10 +2262,25 @@
       "resolved": "https://registry.npmjs.org/setheader/-/setheader-0.0.4.tgz",
       "integrity": "sha1-km7SjPdiFJYgkx566j8blYFuxpQ="
     },
+    "shebang-command": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo="
+    },
+    "shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
+    },
     "shelljs": {
       "version": "0.7.8",
       "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.8.tgz",
       "integrity": "sha1-3svPh0sNHl+3LhSxZKloMEjprLM="
+    },
+    "signal-exit": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
     },
     "slash": {
       "version": "1.0.0",
@@ -2182,6 +2384,11 @@
       "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
       "dev": true
     },
+    "strip-eof": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
+    },
     "strip-json-comments": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
@@ -2191,6 +2398,11 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
       "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+    },
+    "term-size": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/term-size/-/term-size-0.1.1.tgz",
+      "integrity": "sha1-hzYLljlsq1dgljcUzaDQy+7K2co="
     },
     "test-exclude": {
       "version": "4.1.1",
@@ -2243,6 +2455,11 @@
       "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-0.0.3.tgz",
       "integrity": "sha1-7Mo6A+VrmvFzhbqsgSrIO5lKli8=",
       "dev": true
+    },
+    "unique-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
+      "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo="
     },
     "unpipe": {
       "version": "1.0.0",
@@ -2302,6 +2519,11 @@
       "resolved": "https://registry.npmjs.org/vlq/-/vlq-0.2.2.tgz",
       "integrity": "sha1-4xbVJXtAuGu0PLjV/qXX9U1rDKE="
     },
+    "which": {
+      "version": "1.2.14",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
+      "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU="
+    },
     "widest-line": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-1.0.0.tgz",
@@ -2321,6 +2543,11 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-2.0.0.tgz",
       "integrity": "sha1-7byQPMOF/ARSPZZqM1UEtVBNG9I="
+    },
+    "yallist": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
     },
     "zen-observable": {
       "version": "0.4.0",

--- a/packages/micro-analytics-cli/package.json
+++ b/packages/micro-analytics-cli/package.json
@@ -31,7 +31,7 @@
     "args": "^2.3.0",
     "flat-file-db": "^1.0.0",
     "is-async-supported": "^1.2.0",
-    "micro": "6.1.0",
+    "micro": "^7.3.3",
     "micro-analytics-adapter-flat-file-db": "^1.3.2",
     "promise": "^7.1.1",
     "shelljs": "^0.7.6",

--- a/packages/micro-analytics-cli/readme.md
+++ b/packages/micro-analytics-cli/readme.md
@@ -44,11 +44,27 @@ To track a view of `x`, simply send a request to `/x`. This is how you'd track p
 </script>
 ```
 
-If you send a `GET` request, the request will increment the views and return the total views for the id. (in this case "x") If you send a `POST` request, the views will increment but you don't get the total views back.
+If you send a `GET` or `POST` request, the request will increment the views and return the total views for the id (in this case "x").
 
 #### `GET` the views without incrementing
 
 If you just want to get the views for an id and don't want to increment the views during a `GET` request, set `inc` to `false` in your query parameter. (`/x?inc=false`)
+
+#### `POST` to add metadata
+
+You can add more metadata to the view by posting a JSON payload with the field `meta`. Everything in that meta field will be set on meta in the view object. You can read
+the data out with the `all` option, see below for more info. Example request that will post the browser useragent string:
+
+```html
+<script>
+  fetch('servicedomain.com' + window.location.pathname, {
+    method: "POST",
+    credentials: "include",
+    headers: {"Content-Type": "application/json"},
+    body: JSON.stringify({meta: { browser: navigator.userAgent }}),
+  })
+</script>
+```
 
 ### Getting all views
 

--- a/packages/micro-analytics-cli/src/handler.js
+++ b/packages/micro-analytics-cli/src/handler.js
@@ -25,11 +25,7 @@ function realtimeHandler(req, res) {
 }
 
 async function readMeta(req) {
-  try {
-    return (await json(req)).meta;
-  } catch (error) {
-    return null;
-  }
+  return (await json(req)).meta;
 }
 
 async function analyticsHandler(req, res) {

--- a/packages/micro-analytics-cli/src/handler.js
+++ b/packages/micro-analytics-cli/src/handler.js
@@ -25,10 +25,12 @@ function realtimeHandler(req, res) {
 }
 
 async function readMeta(req) {
-  if (await text(req)) {
+  try {
     return (await json(req)).meta;
+  } catch (error) {
+    console.error('Failed parsing meta', error);
+    return null;
   }
-  return null;
 }
 
 async function analyticsHandler(req, res) {
@@ -56,13 +58,16 @@ async function analyticsHandler(req, res) {
   if (pathname.length <= 1) {
     throw createError(400, 'Please include a path to a page.');
   }
+
   if (req.method === 'OPTIONS') {
     res.setHeader('Access-Control-Allow-Headers', 'content-type');
     return send(res, 204);
   }
+
   if (req.method !== 'GET' && req.method !== 'POST') {
     throw createError(400, 'Please make a GET or a POST request.');
   }
+
   const shouldIncrement = String(query.inc) !== 'false';
   try {
     let meta;

--- a/packages/micro-analytics-cli/src/handler.js
+++ b/packages/micro-analytics-cli/src/handler.js
@@ -53,6 +53,10 @@ async function analyticsHandler(req, res) {
   if (pathname.length <= 1) {
     throw createError(400, 'Please include a path to a page.');
   }
+  if (req.method === 'OPTIONS') {
+    res.setHeader('Access-Control-Allow-Headers', 'content-type');
+    return send(res, 204);
+  }
   if (req.method !== 'GET' && req.method !== 'POST') {
     throw createError(400, 'Please make a GET or a POST request.');
   }

--- a/packages/micro-analytics-cli/tests/items.test.js
+++ b/packages/micro-analytics-cli/tests/items.test.js
@@ -41,9 +41,20 @@ describe('single', () => {
     expect(body.views).toEqual(1);
   });
 
-  it('should not return anything for a POST request', async () => {
-    const body = await request.post(`${server.url}/existant`);
-    expect(body).toEqual('');
+  describe('POST', () => {
+    it('should increment the views of an existant path', async () => {
+      await request.post(`${server.url}/existant`);
+      const body = JSON.parse(await request(`${server.url}/existant`));
+      expect(body.views).toEqual(2);
+    });
+
+    it('should increment the views of an existant path and store metadata', async () => {
+      await request.post(`${server.url}/existant`, {
+        body: JSON.stringify({ meta: { browser: 'IE 6' } }),
+      });
+      const [data] = (await db.get('/existant')).views;
+      expect(data).toMatchObject({ meta: { browser: 'IE 6' } });
+    });
   });
 });
 


### PR DESCRIPTION
Excerpt from docs:

>You can add more metadata to the view by posting a JSON payload with the field `meta`. Everything in that meta field will be set on meta in the view object. You can read
 the data out with the `all` option, see below for more info. Example request that will post the browser useragent string:

 ```html
 <script>
   fetch('servicedomain.com' + window.location.pathname, {
     method: "POST",
     credentials: "include",
     headers: {"Content-Type": "application/json"},
     body: JSON.stringify({meta: { browser: navigator.userAgent }}),
   })
 </script>
 ```